### PR TITLE
Use setuptools by default for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To install cJuman, run
 
    % sudo python setup.py install
 
+To create wheel 
+--------------------
+
+To create whl archive, the setuptools and wheel are needed.
+
+   % python setup.py bdist_wheel
 
 License
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
 
 ext_module = Extension('_cJuman',
                        sources=['cJuman_wrap.c'],


### PR DESCRIPTION
I want to use wheel package to deploy cJuman. To create whl archive, setuptools and wheel are needed. Now setuptools is de facto standard packaging tool in Python community. So, could you consider to change default packaging library?

https://wheel.readthedocs.org/en/latest/
